### PR TITLE
Fix typo

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
     - monit_process_group_list
     - monit_process_host_list
     - monit_process_dependent_list
-  when: item.delete is undefined and not item.delete and
+  when: item.delete is defined and not item.delete and
         item.pid is defined and item.pid
   notify: [ 'Test monit and reload' ]
 


### PR DESCRIPTION
Not sure why it never tripped up Ansible now, but `item.delete is undefined and not item.delete` can't work together.