### PR TITLE
Try to fix monit

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
     - monit_process_group_list
     - monit_process_host_list
     - monit_process_dependent_list
-  when: item.delete is undefined and not item.delete and
+  when: item.delete is undefined and
         item.pid is defined and item.pid
   notify: [ 'Test monit and reload' ]
 


### PR DESCRIPTION
How can we test "not item.delete" if in the previous test (item.delete is undefined) we explicitly said the object should no exist. Am I missing something here? Should it fix this issue?